### PR TITLE
fix the orientation of new uv-mapping of ovus to be similar to cylinder

### DIFF
--- a/source/core/shape/ovus.cpp
+++ b/source/core/shape/ovus.cpp
@@ -981,7 +981,7 @@ void Ovus::CalcUV(const Vector3d& IPoint, Vector2d& Result) const
         theta = 0;
 
     Result[U] = theta;
-    Result[V] = phi;
+    Result[V] = 1.0-phi;
 
 }
 


### PR DESCRIPTION
and lemon.

Start from a commit which does not fail the automatic verification