### PR TITLE
Correct (historical) typo for Julia fractal with hypercomplex

### DIFF
--- a/source/core/math/hypercomplex.cpp
+++ b/source/core/math/hypercomplex.cpp
@@ -890,7 +890,7 @@ bool HypercomplexFunctionFractalRules::Iterate(const Vector3d& IPoint, const Fra
 
     x = IterStack[X][0] = IPoint[X];
     y = IterStack[Y][0] = IPoint[Y];
-    z = IterStack[Z][0] = IPoint[Y];
+    z = IterStack[Z][0] = IPoint[Z];
     w = IterStack[W][0] = (HCompl->SliceDist
                          - HCompl->Slice[X]*x
                          - HCompl->Slice[Y]*y


### PR DESCRIPTION
a small typo, a huge impact on rendered fractal (where .y component was used also as .z )

Without correction, the z component just get ignored and replaced by the y component.