### PR TITLE
Fix hard crash in `#declare Foo[A][B]=...` if `Foo` is an array of ar…

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -79,6 +79,10 @@ Reported via GitHub:
 
 Reported via the Newsgroups:
 
+  - <web.5b8350d429c104f2458c7afe0@news.povray.org>
+    (2018-08-27, povray.advanced-users, "Re: It gets even weirder.")
+    Trying to `#declare Foo[A][B]=...` with `Foo` being an array of arrays and
+    `Foo[A]` not yet initialized causes a hard crash instead of a parse error.
   - <web.59fefd5f68f4d962ca73ee9d0@news.povray.org>
     (2017-11-05, povray.newusers, "orthographic camera and conic_sweep object")
     Sides of a `conic_sweep` prism become invisible when viewed head-on using

--- a/source/parser/parser_tokenizer.cpp
+++ b/source/parser/parser_tokenizer.cpp
@@ -1479,6 +1479,11 @@ void Parser::Read_Symbol()
                             a = reinterpret_cast<POV_ARRAY *>(*(Token.DataPtr));
                             j = 0;
 
+                            if (a == nullptr)
+                                // This happens in e.g. `#declare Foo[A][B]=...` when `Foo` is an
+                                // array of arrays and `Foo[A]` is uninitialized.
+                                Error("Attempt to access uninitialized nested array.");
+
                             for (i=0; i <= a->Dims; i++)
                             {
                                 Parse_Square_Begin();
@@ -1507,6 +1512,11 @@ void Parser::Read_Symbol()
 
                             if (!LValue_Ok && !Inside_Ifdef)
                             {
+                                // Note that this does not (and must not) trigger in e.g.
+                                // `#declare Foo[A][B]=...` when `Foo` is an array of arrays and
+                                // `Foo[A]` is uninitialized, because until now we've only seen
+                                // `#declare Foo[A]`, which is no reason for concern as it may
+                                // just as well be part of `#declare Foo[A]=...` which is fine.
                                 if (a->DataPtrs[j] == NULL)
                                     Error("Attempt to access uninitialized array element.");
                             }


### PR DESCRIPTION
…rays and `Foo[A]` is uninitialized.