### PR TITLE
Disable new UV mappings of cylinder, cone and lemon primitives for now.

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -54,6 +54,8 @@ Changed Behaviour
   - Token counting in conditional blocks (e.g. in `#if ... #end`) has changed.
     Whenever such a block is skipped, the token count is now incremented only
     by directives (stuff that begins with `#`).
+  - UV mapping of cylinder, cone and lemon primitives has been disabled again
+    for now, due to their orientation being poorly defined.
 
 New Features
 ------------

--- a/source/core/shape/cone.cpp
+++ b/source/core/shape/cone.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -927,6 +927,8 @@ void Cone::Compute_BBox()
 
 
 
+#ifdef POV_ENABLE_CONE_UV
+
 /*****************************************************************************
 *
 * FUNCTION
@@ -1051,5 +1053,6 @@ void Cone::CalcUV(const Vector3d& IPoint, Vector2d& Result) const
 
 }
 
+#endif // POV_ENABLE_CONE_UV
 
 }

--- a/source/core/shape/cone.h
+++ b/source/core/shape/cone.h
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -86,7 +86,13 @@ class Cone : public ObjectBase
         virtual bool All_Intersections(const Ray&, IStack&, TraceThreadData *);
         virtual bool Inside(const Vector3d&, TraceThreadData *) const;
         virtual void Normal(Vector3d&, Intersection *, TraceThreadData *) const;
+#ifdef POV_ENABLE_CONE_UV
+        /// @attention
+        ///     UV mapping of this primitive should not be enabled until the primary
+        ///     parameterization has been amended so that users have full control over the
+        ///     primitive's  orientation, rather than just the axis of rotational symmetry.
         virtual void UVCoord(Vector2d&, const Intersection *, TraceThreadData *) const;
+#endif // POV_ENABLE_CONE_UV
         virtual void Translate(const Vector3d&, const TRANSFORM *);
         virtual void Rotate(const Vector3d&, const TRANSFORM *);
         virtual void Scale(const Vector3d&, const TRANSFORM *);
@@ -97,7 +103,9 @@ class Cone : public ObjectBase
         void Compute_Cylinder_Data();
     protected:
         int Intersect(const BasicRay& ray, CONE_INT *Intersection, TraceThreadData *Thread) const;
+#ifdef POV_ENABLE_CONE_UV
         void CalcUV(const Vector3d& IPoint, Vector2d& Result) const;
+#endif // POV_ENABLE_CONE_UV
 };
 
 /// @}

--- a/source/core/shape/disc.h
+++ b/source/core/shape/disc.h
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -79,7 +79,10 @@ class Disc : public ObjectBase
         virtual bool All_Intersections(const Ray&, IStack&, TraceThreadData *);
         virtual bool Inside(const Vector3d&, TraceThreadData *) const;
         virtual void Normal(Vector3d&, Intersection *, TraceThreadData *) const;
-        // virtual void UVCoord(Vector2d&, const Intersection *, TraceThreadData *) const; // TODO FIXME - why is there no UV-mapping for this object?
+        // NOTE: UV mapping of this primitive should not be implemented without also amending
+        // the primary parameterization so that users have full control over the primitive's
+        // orientation, rather than just the normal vector.
+        // virtual void UVCoord(Vector2d&, const Intersection *, TraceThreadData *) const;
         virtual void Translate(const Vector3d&, const TRANSFORM *);
         virtual void Rotate(const Vector3d&, const TRANSFORM *);
         virtual void Scale(const Vector3d&, const TRANSFORM *);

--- a/source/core/shape/lemon.cpp
+++ b/source/core/shape/lemon.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -754,6 +754,8 @@ void Lemon::Compute_BBox()
 }
 
 
+#ifdef POV_ENABLE_LEMON_UV
+
 /*****************************************************************************
 *
 * FUNCTION
@@ -876,5 +878,7 @@ void Lemon::CalcUV(const Vector3d& IPoint, Vector2d& Result) const
     Result[V] = phi;
 
 }
+
+#endif // POV_ENABLE_LEMON_UV
 
 }

--- a/source/core/shape/lemon.h
+++ b/source/core/shape/lemon.h
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -82,7 +82,13 @@ class Lemon : public ObjectBase
         virtual bool All_Intersections(const Ray&, IStack&, TraceThreadData *);
         virtual bool Inside(const Vector3d&, TraceThreadData *) const;
         virtual void Normal(Vector3d&, Intersection *, TraceThreadData *) const;
+#ifdef POV_ENABLE_LEMON_UV
+        /// @attention
+        ///     UV mapping of this primitive should not be enabled until the primary
+        ///     parameterization has been amended so that users have full control over the
+        ///     primitive's  orientation, rather than just the axis of rotational symmetry.
         virtual void UVCoord(Vector2d&, const Intersection *, TraceThreadData *) const;
+#endif // POV_ENABLE_LEMON_UV
         virtual void Translate(const Vector3d&, const TRANSFORM *);
         virtual void Rotate(const Vector3d&, const TRANSFORM *);
         virtual void Scale(const Vector3d&, const TRANSFORM *);
@@ -100,7 +106,9 @@ class Lemon : public ObjectBase
         DBL VerticalPosition;   /* vertical position of the center of the inner circle */
     protected:
         int Intersect(const Vector3d& P, const Vector3d& D, LEMON_INT *Intersection, TraceThreadData *Thread) const;
+#ifdef POV_ENABLE_LEMON_UV
         void CalcUV(const Vector3d& IPoint, Vector2d& Result) const;
+#endif // POV_ENABLE_LEMON_UV
 };
 
 /// @}


### PR DESCRIPTION
Resync with official master